### PR TITLE
feat: Fix CI failures

### DIFF
--- a/embassy-executor-macros/Cargo.toml
+++ b/embassy-executor-macros/Cargo.toml
@@ -20,6 +20,7 @@ proc-macro2 = "1.0.29"
 
 [lib]
 proc-macro = true
+doctest = false
 
 [features]
 nightly = []

--- a/embassy-futures/Cargo.toml
+++ b/embassy-futures/Cargo.toml
@@ -14,6 +14,9 @@ categories = [
     "asynchronous",
 ]
 
+[lib]
+doctest = false
+
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-futures-v$VERSION/embassy-futures/src/"
 src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-futures/src/"

--- a/embassy-time-queue-driver/Cargo.toml
+++ b/embassy-time-queue-driver/Cargo.toml
@@ -20,6 +20,9 @@ categories = [
 # This is especially common when mixing crates from crates.io and git.
 links = "embassy-time-queue"
 
+[lib]
+doctest = false
+
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-time-queue-driver-v$VERSION/embassy-time-queue-driver/src/"
 src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-time-queue-driver/src/"


### PR DESCRIPTION
These projects fail `cargo test` because `cargo test` tries to compile all example code by default. I could just wholly disable the `cargo test` build step for these projects, which wouldn't require any changes to the code, but that seems overly aggressive. And it is, in fact, the code's fault anyway, so seems like a reasonable fix to me.