### PR TITLE
Don't enable PLL if not given config

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-stm32"
-version = "0.1001.0"
+version = "0.1001.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Embassy Hardware Abstraction Layer (HAL) for ST STM32 series microcontrollers"

--- a/embassy-stm32/src/rcc/l.rs
+++ b/embassy-stm32/src/rcc/l.rs
@@ -589,7 +589,7 @@ mod pll {
         // Disable PLL
         pll_enable(instance, false);
 
-        let Some(pll) = config else { return PllOutput::default() };
+        if let Some(pll) = config {
 
         let pll_src = match pll.source {
             PllSource::DISABLE => panic!("must not select PLL source as DISABLE"),
@@ -656,5 +656,8 @@ mod pll {
         pll_enable(instance, true);
 
         PllOutput { p, q, r }
+    } else {
+        PllOutput { p: None, q: None, r: None }
+    }
     }
 }


### PR DESCRIPTION
If we pass `None` as the PLL option, it means we don't want it enabled, not we are looking for defaults.