### PR TITLE
build: Reference local embassy projects

### DIFF
--- a/embassy-boot-stm32/Cargo.toml
+++ b/embassy-boot-stm32/Cargo.toml
@@ -25,9 +25,9 @@ defmt = { version = "0.3", optional = true }
 defmt-rtt = { version = "0.4", optional = true }
 log = { version = "0.4", optional = true }
 
-embassy-sync = { version = "0.5001.0", registry = "artifactory" }
-embassy-stm32 = { version = "0.1001.0", registry = "artifactory", default-features = false, features=["rt"]}
-embassy-boot = { version = "0.2001.0", registry = "artifactory" }
+embassy-sync = { version = "0.5001.0", registry = "artifactory", path = "../embassy-sync" }
+embassy-stm32 = { version = "0.1001.0", registry = "artifactory", path = "../embassy-stm32", default-features = false, features=["rt"]}
+embassy-boot = { version = "0.2001.0", registry = "artifactory", path = "../embassy-boot" }
 cortex-m = { version = "0.7.6" }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.1"

--- a/embassy-boot/Cargo.toml
+++ b/embassy-boot/Cargo.toml
@@ -28,8 +28,8 @@ defmt = { version = "0.3", optional = true }
 digest = "0.10"
 log = { version = "0.4", optional = true }
 ed25519-dalek = { version = "2", default_features = false, features = ["digest"], optional = true }
-embassy-embedded-hal = { version = "0.1001.0", registry = "artifactory" }
-embassy-sync = { version = "0.5001.0", registry = "artifactory" }
+embassy-embedded-hal = { version = "0.1001.0", registry = "artifactory", path = "../embassy-embedded-hal" }
+embassy-sync = { version = "0.5001.0", registry = "artifactory", path = "../embassy-sync" }
 embedded-storage = "0.3.1"
 embedded-storage-async = { version = "0.4.1" }
 salty = { version = "0.3", optional = true }

--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -27,9 +27,9 @@ time = ["dep:embassy-time"]
 default = ["time"]
 
 [dependencies]
-embassy-futures = { version = "0.1001.0", registry = "artifactory" }
-embassy-sync = { version = "0.5001.0",  registry = "artifactory" }
-embassy-time = { version = "0.3001.0",  registry = "artifactory", optional = true }
+embassy-futures = { version = "0.1001.0", registry = "artifactory", path = "../embassy-futures" }
+embassy-sync = { version = "0.5001.0",  registry = "artifactory", path = "../embassy-sync" }
+embassy-time = { version = "0.3001.0",  registry = "artifactory", path = "../embassy-time", optional = true }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
     "unproven",
 ] }

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -33,9 +33,9 @@ defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 rtos-trace = { version = "0.1.2", optional = true }
 
-embassy-executor-macros = { version = "0.4001.0", registry = "artifactory" }
-embassy-time-driver = { version = "0.1001.0", optional = true, registry = "artifactory" }
-embassy-time-queue-driver = { version = "0.1001.0", optional = true, registry = "artifactory" }
+embassy-executor-macros = { version = "0.4001.0", registry = "artifactory", path = "../embassy-executor-macros" }
+embassy-time-driver = { version = "0.1001.0", optional = true, registry = "artifactory", path = "../embassy-time-driver" }
+embassy-time-queue-driver = { version = "0.1001.0", optional = true, registry = "artifactory", path = "../embassy-time-queue-driver" }
 critical-section = "1.1"
 
 document-features = "0.2.7"

--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -19,13 +19,13 @@ features = ["stm32wb55rg"]
 features = ["stm32wb55rg"]
 
 [dependencies]
-embassy-stm32 = { version = "0.1001.0", registry = "artifactory", default-features = false, features=["rt"]}
-embassy-sync = { version = "0.5001.0", registry = "artifactory" }
-embassy-time = { version = "0.3001.0", optional = true, registry = "artifactory" }
-embassy-futures = { version = "0.1001.0", registry = "artifactory" }
-embassy-hal-internal = { version = "0.1001.0", registry = "artifactory" }
-embassy-embedded-hal = { version = "0.1001.0", registry = "artifactory" }
-embassy-net-driver = { version = "0.2001.0", optional=true, registry = "artifactory" }
+embassy-stm32 = { version = "0.1001.0", registry = "artifactory", path = "../embassy-stm32", default-features = false, features=["rt"]}
+embassy-sync = { version = "0.5001.0", registry = "artifactory", path = "../embassy-sync" }
+embassy-time = { version = "0.3001.0", optional = true, registry = "artifactory", path = "../embassy-time" }
+embassy-futures = { version = "0.1001.0", registry = "artifactory", path = "../embassy-futures" }
+embassy-hal-internal = { version = "0.1001.0", registry = "artifactory", path = "../embassy-hal-internal"  }
+embassy-embedded-hal = { version = "0.1001.0", registry = "artifactory", path = "../embassy-embedded-hal" }
+embassy-net-driver = { version = "0.2001.0", optional=true, registry = "artifactory", path = "../embassy-net-driver" }
 
 defmt = { version = "0.3", optional = true }
 cortex-m = "0.7.6"

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -42,16 +42,16 @@ features = ["defmt", "unstable-pac", "exti", "time-driver-any", "time", "stm32h7
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-embassy-sync = { version = "0.5001.0", registry = "artifactory" }
-embassy-time = { version = "0.3001.0", optional = true, registry = "artifactory" }
-embassy-time-driver = { version = "0.1001", optional = true, registry = "artifactory" }
-embassy-futures = { version = "0.1001.0", registry = "artifactory" }
-embassy-hal-internal = { version = "0.1001.0", registry = "artifactory", features = ["cortex-m", "prio-bits-4"] }
-embassy-embedded-hal = { version = "0.1001.0", registry = "artifactory" }
-embassy-net-driver = { version = "0.2001.0", optional=true, registry = "artifactory" }
-embassy-usb-driver = {version = "0.1001.0", registry = "artifactory" }
-embassy-usb-synopsys-otg = {version = "0.1001.0", registry = "artifactory" }
-embassy-executor = { version = "0.5001.0", optional = true, registry = "artifactory" }
+embassy-sync = { version = "0.5001.0", registry = "artifactory", path = "../embassy-sync" }
+embassy-time = { version = "0.3001.0", optional = true, registry = "artifactory", path="../embassy-time" }
+embassy-time-driver = { version = "0.1001", optional = true, registry = "artifactory", path="../embassy-time-driver" }
+embassy-futures = { version = "0.1001.0", registry = "artifactory", path = "../embassy-futures" }
+embassy-hal-internal = { version = "0.1001.0", registry = "artifactory", path="../embassy-hal-internal", features = ["cortex-m", "prio-bits-4"] }
+embassy-embedded-hal = { version = "0.1001.0", registry = "artifactory", path="../embassy-embedded-hal" }
+embassy-net-driver = { version = "0.2001.0", optional=true, registry = "artifactory", path="../embassy-net-driver" }
+embassy-usb-driver = {version = "0.1001.0", registry = "artifactory", path="../embassy-usb-driver" }
+embassy-usb-synopsys-otg = {version = "0.1001.0", registry = "artifactory", path="../embassy-usb-synopsys-otg" }
+embassy-executor = { version = "0.5001.0", optional = true, registry = "artifactory", path="../embassy-executor" }
 
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -398,8 +398,8 @@ tick-hz-5_242_880_000 = ["embassy-time-driver/tick-hz-5_242_880_000"]
 #! </details>
 
 [dependencies]
-embassy-time-driver = { version = "0.1001.0", registry = "artifactory" }
-embassy-time-queue-driver = { version = "0.1001.0", registry = "artifactory" }
+embassy-time-driver = { version = "0.1001.0", registry = "artifactory", path = "../embassy-time-driver" }
+embassy-time-queue-driver = { version = "0.1001.0", registry = "artifactory", path = "../embassy-time-queue-driver" }
 
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
@@ -423,4 +423,4 @@ wasm-timer = { version = "0.2.5", optional = true }
 [dev-dependencies]
 serial_test = "0.9"
 critical-section = { version = "1.1", features = ["std"] }
-embassy-executor = { version = "0.5001.0", registry = "artifactory" }
+embassy-executor = { version = "0.5001.0", registry = "artifactory", path = "../embassy-executor" }

--- a/embassy-usb-synopsys-otg/Cargo.toml
+++ b/embassy-usb-synopsys-otg/Cargo.toml
@@ -18,8 +18,8 @@ target = "thumbv7em-none-eabi"
 [dependencies]
 critical-section = "1.1"
 
-embassy-sync = { version = "0.5001.0", registry = "artifactory" }
-embassy-usb-driver = {version = "0.1001.0", registry = "artifactory" }
+embassy-sync = { version = "0.5001.0", registry = "artifactory", path = "../embassy-sync" }
+embassy-usb-driver = {version = "0.1001.0", registry = "artifactory", path = "../embassy-usb-driver" }
 
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }


### PR DESCRIPTION
This is largely a reversion of
b50fa13cfb1b8d47f2eab3d629ef4f67bfdb961f, but with the caveat that we can have BOTH path and registry in the dependency line. So, what we should have done originally was just add `registry = "artifactory"`, not replace it.