### PR TITLE
[TR3FIR-345] Bump stm32wb-hci version

### DIFF
--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -36,7 +36,7 @@ aligned = "0.4.1"
 
 bit_field = "0.10.2"
 stm32-device-signature = { version = "0.3.3", features = ["stm32wb5x"] }
-stm32wb-hci = { version = "0.1703.0", optional = true, registry = "artifactory" }
+stm32wb-hci = { version = "0.1703.2", optional = true, registry = "artifactory" }
 futures-util = { version = "0.3.30", default-features = false }
 bitflags = { version = "2.3.3", optional = true }
 


### PR DESCRIPTION
New version fixes handling of the
`ACI_L2CAP_CONNECTION_UPDATE_RESP_EVENT` event and in turn gets rid of the `BadLength` errors.