### PR TITLE
SW-1286 updating embassy config for I2C to prevent pull down

### DIFF
--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -88,7 +88,7 @@ impl Config {
             Speed::Medium,
             match self.scl_pullup {
                 true => Pull::Up,
-                false => Pull::Down,
+                false => Pull::None,
             },
         );
     }
@@ -102,7 +102,7 @@ impl Config {
             Speed::Medium,
             match self.sda_pullup {
                 true => Pull::Up,
-                false => Pull::Down,
+                false => Pull::None,
             },
         );
     }


### PR DESCRIPTION
🧾 Summary
Modified default config for I2C lines related to pull up/down resistors. Previous config interpreted a false in the pull up variable to mean pull down was requested, however, I2C lines have pull up resistors external. By enabling a pull down resistor inside the MCU, this creates a voltage divider and consumes unnecessary current.

Pull Request — token-main
This PR should target the token-main branch. If this is not the case, immediately reject.

⚠️ Merge Strategy (IMPORTANT) ⚠️
Squash merge may be used on feature PRs into develop ONLY. Release PRs back into develop SHALL NOT squash merge.
Regular merge (no squash) is always allowed, with an additional caveat if a feature PR.
Commits must be organized with each commit referencing the associated JIRA ticket (e.g., SW-123).
In short, squash merge may only be used when merging a feature branch into develop.